### PR TITLE
Let the creator demo run alongside sibling-repo demos

### DIFF
--- a/bin/containers_up_healthy_and_clean.sh
+++ b/bin/containers_up_healthy_and_clean.sh
@@ -3,8 +3,6 @@
 server_up_healthy_and_clean()
 {
   export SERVICE_NAME=creator
-  export CONTAINER_NAME="${CYBER_DOJO_CREATOR_SERVER_CONTAINER_NAME}"
-  export CONTAINER_PORT="${CYBER_DOJO_CREATOR_PORT}"
   docker compose up --detach "${SERVICE_NAME}"
   exit_non_zero_unless_healthy
 }
@@ -14,8 +12,6 @@ client_up_healthy_and_clean()
 {
   if [ "${1:-}" != 'server' ]; then
     export SERVICE_NAME=client
-    export CONTAINER_NAME="${CYBER_DOJO_CREATOR_CLIENT_CONTAINER_NAME}"
-    export CONTAINER_PORT="${CYBER_DOJO_CREATOR_CLIENT_PORT}"
     docker compose up --detach nginx_stub
     exit_non_zero_unless_healthy
   fi
@@ -46,11 +42,16 @@ exit_non_zero_unless_healthy()
 # - - - - - - - - - - - - - - - - - - -
 healthy()
 {
-  docker ps --filter health=healthy --format '{{.Names}}' | grep -q "${CONTAINER_NAME}"
+  # Containers are no longer given fixed names (so concurrent demos/tests in
+  # sibling repos do not collide), so resolve the service's container id by
+  # its compose project+service label - see service_container in lib.sh.
+  local -r cid="$(service_container "${SERVICE_NAME}")"
+  [ -n "${cid}" ] && \
+    docker ps --filter health=healthy --format '{{.ID}}' | grep -q "${cid}"
 }
 
 # - - - - - - - - - - - - - - - - - - -
 echo_docker_log()
 {
-  docker logs "${CONTAINER_NAME}" 2>&1
+  docker logs "$(service_container "${SERVICE_NAME}")" 2>&1
 }

--- a/bin/copy_in_saver_test_data.sh
+++ b/bin/copy_in_saver_test_data.sh
@@ -2,7 +2,7 @@
 copy_in_saver_test_data()
 {
   local -r SRC_PATH=$(repo_root)/test/data
-  local -r SAVER_CID=$(docker ps --filter status=running --format '{{.Names}}' | grep "saver")
+  local -r SAVER_CID="$(service_container saver)"
   local -r DEST_PATH=/cyber-dojo
 
   # You cannot docker cp to a tmpfs, so tar-piping instead...

--- a/bin/demo.sh
+++ b/bin/demo.sh
@@ -22,6 +22,15 @@ export DOCKER_DEFAULT_PLATFORM=linux/amd64
 # shellcheck disable=SC2046
 export $(echo_env_vars)
 
+# Each demo runs as its own docker-compose project so this repo's demo can
+# run alongside a sibling repo's demo (eg web) without their networks,
+# container names or host ports colliding. The backend services are no
+# longer published to the host (they talk over the project's private
+# network); only nginx is, on an overridable host port, eg:
+#   CYBER_DOJO_NGINX_HOST_PORT=81 bin/demo.sh
+# (creator is the one exception - api_demo below curls it directly on
+# CYBER_DOJO_CREATOR_PORT to bypass nginx's /creator/ rate-limit.)
+export COMPOSE_PROJECT_NAME="${COMPOSE_PROJECT_NAME:-creator}"
 export CYBER_DOJO_NGINX_HOST_PORT="${CYBER_DOJO_NGINX_HOST_PORT:-80}"
 
 compose()

--- a/bin/echo_env_vars.sh
+++ b/bin/echo_env_vars.sh
@@ -33,7 +33,4 @@ echo_env_vars()
   #
   echo CYBER_DOJO_CREATOR_CLIENT_USER=nobody
   echo CYBER_DOJO_CREATOR_SERVER_USER=nobody
-  #
-  echo CYBER_DOJO_CREATOR_CLIENT_CONTAINER_NAME=test_creator_client
-  echo CYBER_DOJO_CREATOR_SERVER_CONTAINER_NAME=test_creator_server
 }

--- a/bin/lib.sh
+++ b/bin/lib.sh
@@ -39,6 +39,20 @@ repo_root()
   git rev-parse --show-toplevel
 }
 
+service_container()
+{
+  # Echo the container id of the given docker-compose service within this
+  # repo's project. The project is COMPOSE_PROJECT_NAME (set by bin/demo.sh),
+  # defaulting to creator so the saver/test helpers also work against a plain
+  # test run, where Compose derives the same project name from the repo
+  # directory.
+  local -r service="${1}"
+  docker ps \
+    --filter "label=com.docker.compose.project=${COMPOSE_PROJECT_NAME:-creator}" \
+    --filter "label=com.docker.compose.service=${service}" \
+    --format '{{.ID}}'
+}
+
 git_commit_sha()
 {
   cd "$(repo_root)" && git rev-parse HEAD

--- a/bin/run_tests_with_coverage.sh
+++ b/bin/run_tests_with_coverage.sh
@@ -23,11 +23,26 @@ run_tests_with_coverage()
   exit_zero_if_show_help "$@"
   exit_non_zero_unless_installed docker jq
 
+  # Clear any containers a previous (failed) run left up for inspection, so
+  # this run starts from a clean slate.
+  containers_down
+
   server_up_healthy_and_clean
   client_up_healthy_and_clean "$@"
   copy_in_saver_test_data
   test_in_containers "$@" || exit_status=$?
-  containers_down
+  if [ "${exit_status}" -eq 0 ]; then
+    containers_down
+  else
+    # Leave the containers (and their volumes) up so their logs survive for
+    # diagnosing the failure - tearing them down here would discard exactly
+    # the evidence you need. The next test run clears them at its start.
+    echo
+    echo "Tests failed - leaving containers up so you can inspect them:"
+    echo "  docker compose logs            # all services"
+    echo "  docker compose logs creator    # just the server"
+    echo "  docker compose down --remove-orphans --volumes   # when done"
+  fi
   write_test_evidence_json "$@"
   set -e
 

--- a/bin/test_in_containers.sh
+++ b/bin/test_in_containers.sh
@@ -25,7 +25,7 @@ run_client_tests()
 {
   run_tests \
     "${CYBER_DOJO_CREATOR_CLIENT_USER}" \
-    "${CYBER_DOJO_CREATOR_CLIENT_CONTAINER_NAME}" \
+    client \
     client "${@:-}";
 }
 
@@ -34,16 +34,21 @@ run_server_tests()
 {
   run_tests \
     "${CYBER_DOJO_CREATOR_SERVER_USER}" \
-    "${CYBER_DOJO_CREATOR_SERVER_CONTAINER_NAME}" \
+    creator \
     server "${@:-}";
 }
 
 # - - - - - - - - - - - - - - - - - - - - - - - - - -
 run_tests()
 {
-  local -r USER="${1}"           # eg nobody
-  local -r CONTAINER_NAME="${2}" # eg test_creator_server
-  local -r TYPE="${3}"           # eg server
+  local -r USER="${1}"    # eg nobody
+  local -r SERVICE="${2}" # compose service, eg creator
+  local -r TYPE="${3}"    # eg server
+
+  # Containers are no longer given fixed names (so concurrent demos/tests in
+  # sibling repos do not collide), so resolve the service's container id by
+  # its compose project+service label - see service_container in lib.sh.
+  local -r CONTAINER_NAME="$(service_container "${SERVICE}")"
 
   echo '=================================='
   echo "Running ${TYPE} tests"

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -12,7 +12,6 @@ services:
   nginx_stub:
     image: cyberdojo/nginx_creator_stub
     platform: linux/amd64
-    container_name: test_nginx
     ports: [ "${CYBER_DOJO_NGINX_PORT}:${CYBER_DOJO_NGINX_PORT}" ]
     user: root
     build:
@@ -28,7 +27,6 @@ services:
       context: client
     image: ${CYBER_DOJO_CREATOR_CLIENT_IMAGE}:${CYBER_DOJO_CREATOR_TAG}
     platform: linux/amd64
-    container_name: ${CYBER_DOJO_CREATOR_CLIENT_CONTAINER_NAME}
     env_file: [ .env ]
     ports: [ "${CYBER_DOJO_CREATOR_CLIENT_PORT}:${CYBER_DOJO_CREATOR_CLIENT_PORT}" ]
     user: ${CYBER_DOJO_CREATOR_CLIENT_USER}
@@ -56,7 +54,6 @@ services:
       context: .
     image: ${CYBER_DOJO_CREATOR_IMAGE}:${CYBER_DOJO_CREATOR_TAG}
     platform: linux/amd64
-    container_name: ${CYBER_DOJO_CREATOR_SERVER_CONTAINER_NAME}
     env_file: [ .env ]
     ports: [ "${CYBER_DOJO_CREATOR_PORT}:${CYBER_DOJO_CREATOR_PORT}" ]
     user: ${CYBER_DOJO_CREATOR_SERVER_USER}
@@ -137,7 +134,6 @@ services:
     image: ${CYBER_DOJO_SAVER_IMAGE}:${CYBER_DOJO_SAVER_TAG}
     platform: linux/amd64
     user: saver
-    ports: [ "${CYBER_DOJO_SAVER_PORT}:${CYBER_DOJO_SAVER_PORT}" ]
     env_file: [ .env ]
     init: true
     read_only: true


### PR DESCRIPTION
  Until now `make demo` brought the stack up on fixed container names and
  fixed host ports (and `make run-tests` shared the same docker-compose.yml).
  So the creator demo could not run while another repo's demo (eg web) was
  up: they fought over the same host ports. This mirrors the equivalent web
  repo change (#358) for the creator.

    - Each demo runs as its own docker-compose project (COMPOSE_PROJECT_NAME, default creator), so networks and container names are namespaced per project. Only nginx is published to the host, on an overridable port (CYBER_DOJO_NGINX_HOST_PORT); backend services talk over the project's private network, so nothing else collides. creator stays published on CYBER_DOJO_CREATOR_PORT because api_demo curls it directly to bypass nginx's /creator/ rate-limit. saver's unused host port is dropped.
    - Drop the per-service container_name so Compose namespaces them. The test/demo helpers no longer assume fixed names; they resolve a container by compose project+service label via a shared service_container() in lib.sh. asset_builder is left alone (not part of the demo; build_assets.sh execs it by its fixed name).

  Also stop destroying the test containers on a failed run: a failed
  `make run-tests` previously ran `compose down` unconditionally, discarding
  the very logs needed to diagnose the failure. It now leaves the containers
  (and volumes) up on failure, with a hint on reading their logs, and clears
  any leftovers at the start of the next run.

  Co-Authored-By: Claude Opus 4.8 (1M context) <noreply@anthropic.com>