### PR TITLE
Choose practice kind before exercise and language-test-framework

### DIFF
--- a/app/assets/stylesheets/creator.scss
+++ b/app/assets/stylesheets/creator.scss
@@ -111,6 +111,46 @@
   }
 }
 
+#choose-type-page button.kata, #choose-type-page button.group
+{
+  display: block;
+  margin-top: 10px;
+  margin-left: auto;
+  margin-right: auto;
+  padding: 10px 12px;
+  @include non-code-font();
+  width: 288px;
+  text-align: left;
+
+  .fork-option-name
+  {
+    display: block;
+    font-size: 28px;
+    letter-spacing: 0.02em;
+    margin-bottom: 4px;
+  }
+
+  ul
+  {
+    margin: 0;
+    padding-left: 1.2em;
+    font-size: 13px;
+    font-weight: normal;
+    list-style: disc;
+    @include plaintext-font();
+  }
+
+  .fork-option-note
+  {
+    display: block;
+    margin-top: 4px;
+    font-size: 12px;
+    font-weight: normal;
+    color: #666;
+    @include plaintext-font();
+  }
+}
+
 #choose-problem-page .help
 {
   position: relative;

--- a/app/views/choose_custom_problem.erb
+++ b/app/views/choose_custom_problem.erb
@@ -6,7 +6,10 @@ $(() => {
 
   $('button.next').click(() => {
     const name = encodeURIComponent(cd.selectedDisplayName);
-    cd.goto(`/creator/choose_type?display_name=${name}`);
+    const params = `${cd.urlParams()}&display_name=${name}`;
+    $.post('/creator/create.json', cd.toJSON(params), (response) => {
+      cd.goto(response.route);
+    });
   });
 
   $('button.switch').click(() => cd.goto(`/creator/choose_problem?${cd.urlParams()}`));

--- a/app/views/choose_ltf.erb
+++ b/app/views/choose_ltf.erb
@@ -6,7 +6,10 @@ $(() => {
 
   $('button.next').click(() => {
     const name = encodeURIComponent(cd.selectedDisplayName);
-    cd.goto(`/creator/choose_type?${cd.urlParams()}&language_name=${name}`);
+    const params = `${cd.urlParams()}&language_name=${name}`;
+    $.post('/creator/create.json', cd.toJSON(params), (response) => {
+      cd.goto(response.route);
+    });
   });
 
 });

--- a/app/views/choose_problem.erb
+++ b/app/views/choose_problem.erb
@@ -6,11 +6,18 @@ $(() => {
 
   $('button.next').click(() => {
     const name = encodeURIComponent(cd.selectedDisplayName);
-    cd.goto(`/creator/choose_ltf?exercise_name=${name}`);
+    cd.goto(`/creator/choose_ltf?${cd.urlParams()}&exercise_name=${name}`);
   });
 
-  $('button.skip').click(() => cd.goto('/creator/choose_ltf?exercise_name='));
-  $('button.switch').click(() => cd.goto('/creator/choose_custom_problem'));
+  // Only a 'single' practice (type=kata) may skip choosing an exercise;
+  // a 'classroom' practice (type=group) must choose one.
+  if (cd.urlParam('type') === 'kata') {
+    $('button.skip').click(() => cd.goto(`/creator/choose_ltf?${cd.urlParams()}&exercise_name=`));
+  } else {
+    $('button.skip').hide();
+  }
+
+  $('button.switch').click(() => cd.goto(`/creator/choose_custom_problem?${cd.urlParams()}`));
 
 });
 </script>

--- a/app/views/choose_type.erb
+++ b/app/views/choose_type.erb
@@ -3,20 +3,10 @@
 $(() => {
 
   cd.setupHomeIcon();
-  
-  const setTypeButtonHandler = (name, type) => {
-	  $(`button.${name}`).click(() => {
-	    const params = cd.urlParams() + `&type=${type}`;
-	    $.post('/creator/create.json', cd.toJSON(params), (response) => {
-	      cd.goto(response.route);
-	    });
-	  });
-  };
-  
-  setTypeButtonHandler('solo', 'kata');
-  setTypeButtonHandler('ensemble', 'kata');
-  setTypeButtonHandler('classroom', 'group');
- 
+
+  $('button.kata' ).click(() => cd.goto('/creator/choose_problem?type=kata'));
+  $('button.group').click(() => cd.goto('/creator/choose_problem?type=group'));
+
 });
 </script>
 
@@ -24,21 +14,24 @@ $(() => {
   <div class="edged-panel">
     <div class="title">create a new practice</div>
     <div class="sub-title">choose your practice type</div>
-	  
-	<table>
-		<tr>
-			<td><button type="button" class="large ensemble">ensemble</button></td>
-			<td>We'll practice together, all taking turns on the <em>same</em> files</td>
-		</tr>
-		<tr>
-			<td><button type="button" class="large classroom">classroom</button></td>
-			<td>We'll practice separately, each using our <em>own</em> files</td>
-		</tr>
-		<tr>
-			<td><button type="button" class="large solo">solo</button></td>
-			<td>I'm working on my own</td>
-		</tr>
-	</table>
-			
+
+    <button class="group" type="button">
+      <span class="fork-option-name">classroom</span>
+      <ul>
+        <li>multiple avatars (eg, lion, salmon, tuna)</li>
+        <li>dashboard showing all avatars</li>
+        <li>each avatar has own source files</li>
+      </ul>
+    </button>
+    <button class="kata" type="button">
+      <span class="fork-option-name">single</span>
+      <ul>
+        <li>no avatar</li>
+        <li>no dashboard</li>
+        <li>one set of source files</li>
+      </ul>
+      <span class="fork-option-note">If you want an ensemble/mob style practice, choose this and take turns.</span>
+    </button>
+
   </div>
 </div>

--- a/app/views/home.erb
+++ b/app/views/home.erb
@@ -2,7 +2,7 @@
 'use strict';
 $(() => {
 
-  $('button.create').click(() => cd.goto('/creator/choose_problem'));
+  $('button.create').click(() => cd.goto('/creator/choose_type'));
   $('button.enter' ).click(() => cd.goto('/creator/enter'));
 
 });

--- a/bin/remove_old_images.sh
+++ b/bin/remove_old_images.sh
@@ -15,7 +15,7 @@ remove_all_but_latest()
   do
     if [ "${image_name}" != "${name}:latest" ]; then
       if [ "${image_name}" != "${name}:<none>" ]; then
-        docker image rm "${image_name}"
+        docker image rm --force "${image_name}"
       fi
     fi
   done


### PR DESCRIPTION
  Picking the kind (single vs classroom) up front is a prerequisite for
  letting a classroom session offer several language-test-frameworks: the
  LTF page needs to know the kind before it renders. Reordering it now,
  ahead of that work, keeps the change small and reviewable.

  Reorder the create flow from exercise -> LTF -> kind to
  kind -> exercise -> LTF. The kind is carried through the URL as `type`
  and mapped to the existing /create.json contract unchanged (group vs
  kata), so no server or Creator changes are needed.

  Collapse the three kind buttons (solo, ensemble, classroom) into the
  two-option model copied from ../web's fork dialog: "single" (kata,
  covering solo and ensemble - take turns) and "classroom" (group),
  including web's descriptive copy and button styling.

  The exercise-skip option is now offered only for a single practice; a
  classroom practice must choose an exercise. The standard path's final
  POST moves to choose_ltf, and the custom path's to choose_custom_problem.

  Also add --force to the docker image rm in bin/remove_old_images.sh so
  `make image` no longer aborts when a leftover demo container still
  references the sha-tagged creator image.

  Co-Authored-By: Claude Opus 4.8 (1M context) <noreply@anthropic.com>