### PR TITLE
Hard-code an explicit 6-char id in every test

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -2,7 +2,7 @@
 SHORT_SHA := $(shell git rev-parse HEAD | head -c7)
 IMAGE_NAME := cyberdojo/creator:${SHORT_SHA}
 
-.PHONY: assets image rubocop-lint snyk-container
+.PHONY: assets image test rubocop-lint snyk-container demo
 
 assets:
 	${PWD}/bin/build_assets.sh

--- a/bin/build_tagged_images.sh
+++ b/bin/build_tagged_images.sh
@@ -11,7 +11,7 @@ export $(echo_env_vars)
 #- - - - - - - - - - - - - - - - - - - - - - - -
 build_tagged_images()
 {
-  if [ "${CI:-}" == 'true' ]; then
+  if on_ci; then
     # In the CI workflow the image is built by a Github Action (secure-docker-build)
     # and the tests run against that downloaded image. Building it here instead would
     # test a different image to the one being attested and deployed.

--- a/test/client/bad_request_raises_test.rb
+++ b/test/client/bad_request_raises_test.rb
@@ -1,20 +1,17 @@
 require_relative 'creator_test_base'
 
 class BadRequestTest < CreatorTestBase
-  def self.id58_prefix
-    :Fy3
-  end
 
   # - - - - - - - - - - - - - - - - -
 
-  qtest e45:
+  qtest Fy3e45:
   %w(group_create_custom([unknown_display_name]) raises exception) do
     _error = assert_raises(HttpJsonHash::ServiceError) do
       creator.deprecated_group_create_custom(['xxx'])
     end
   end
 
-  qtest a45:
+  qtest Fy3a45:
   %w(kata_create_custom(unknown_display_name) raises exception) do
     _error = assert_raises(HttpJsonHash::ServiceError) do
       creator.deprecated_kata_create_custom('xxx')

--- a/test/client/bad_response_raises_test.rb
+++ b/test/client/bad_response_raises_test.rb
@@ -2,13 +2,10 @@ require_relative 'creator_test_base'
 require 'ostruct'
 
 class BadResponseRaisesTest < CreatorTestBase
-  def self.id58_prefix
-    :f2G
-  end
 
   # - - - - - - - - - - - - - - - - -
 
-  qtest a34:
+  qtest f2Ga34:
   %w[http body not JSON raises] do
     creator_http_stub('{42:"sd"}')
     error = assert_raises(HttpJsonHash::ServiceError) { externals.creator.ready? }
@@ -18,7 +15,7 @@ class BadResponseRaisesTest < CreatorTestBase
 
   # - - - - - - - - - - - - - - - - -
 
-  qtest b34:
+  qtest f2Gb34:
   %w[http body not JSON Hash raises] do
     creator_http_stub('42')
     error = assert_raises(HttpJsonHash::ServiceError) { externals.creator.ready? }
@@ -28,7 +25,7 @@ class BadResponseRaisesTest < CreatorTestBase
 
   # - - - - - - - - - - - - - - - - -
 
-  qtest c34:
+  qtest f2Gc34:
   %w[http body JSON without key for method name raises] do
     creator_http_stub('{}')
     error = assert_raises(HttpJsonHash::ServiceError) { externals.creator.ready? }

--- a/test/client/max_metrics.json
+++ b/test/client/max_metrics.json
@@ -20,7 +20,7 @@
 
   "test": {
     "lines": {
-       "total":139,
+       "total":129,
       "missed":7
     },
     "branches": {

--- a/test/client/probe_test.rb
+++ b/test/client/probe_test.rb
@@ -1,17 +1,14 @@
 require_relative 'creator_test_base'
 
 class ProbeTest < CreatorTestBase
-  def self.id58_prefix
-    :a87
-  end
 
   # - - - - - - - - - - - - - - - - -
 
-  qtest d15: %w[its alive] do
+  qtest a87d15: %w[its alive] do
     assert true?(creator.alive?)
   end
 
-  qtest d16: %w[its ready] do
+  qtest a87d16: %w[its ready] do
     assert true?(creator.ready?)
   end
 end

--- a/test/client/sha_test.rb
+++ b/test/client/sha_test.rb
@@ -1,13 +1,10 @@
 require_relative 'creator_test_base'
 
 class ShaTest < CreatorTestBase
-  def self.id58_prefix
-    :de3
-  end
 
   # - - - - - - - - - - - - - - - - -
 
-  qtest p23: %w[sha is 40-char git commit sha] do
+  qtest de3p23: %w[sha is 40-char git commit sha] do
     sha = creator.sha
     assert git_sha?(sha), sha
   end

--- a/test/client/view_200_test.rb
+++ b/test/client/view_200_test.rb
@@ -1,53 +1,50 @@
 require_relative 'creator_test_base'
 
 class View200Test < CreatorTestBase
-  def self.id58_prefix
-    :a97
-  end
 
   # - - - - - - - - - - - - - - - - -
 
-  qtest d13: %w[home] do
+  qtest a97d13: %w[home] do
     visit('/')
     assert page.html.include?('<title>cyber-dojo</title>'), :failed_to_render
     visit('/creator/home')
     assert page.html.include?('<title>cyber-dojo</title>'), :failed_to_render
   end
 
-  qtest d16: %w[choose_problem] do
+  qtest a97d16: %w[choose_problem] do
     visit('/creator/choose_problem')
     assert page.html.include?('<title>cyber-dojo</title>'), :failed_to_render
   end
 
-  qtest d17: %w[choose_custom_problem] do
+  qtest a97d17: %w[choose_custom_problem] do
     visit('/creator/choose_custom_problem')
     assert page.html.include?('<title>cyber-dojo</title>'), :failed_to_render
   end
 
-  qtest d18: %w[choose_ltf] do
+  qtest a97d18: %w[choose_ltf] do
     exercise_name = any_exercises_start_points_display_name
     visit("/creator/choose_ltf?exercise_name=#{exercise_name}")
     assert page.html.include?('<title>cyber-dojo</title>'), :failed_to_render
   end
 
-  qtest d19: %w[choose_type] do
+  qtest a97d19: %w[choose_type] do
     exercise_name = any_exercises_start_points_display_name
     language_name = any_languages_start_points_display_name
     visit("/creator/choose_type?exercise_name=#{exercise_name}&language_name=#{language_name}")
     assert page.html.include?('<title>cyber-dojo</title>'), :failed_to_render
   end
 
-  qtest d20: %w[enter] do
+  qtest a97d20: %w[enter] do
     visit('/creator/enter?id=chy6BJ')
     assert page.html.include?('<title>cyber-dojo</title>'), :failed_to_render
   end
 
-  qtest d21: %w[reenter] do
+  qtest a97d21: %w[reenter] do
     visit('/creator/reenter?id=chy6BJ')
     assert page.html.include?('<title>cyber-dojo</title>'), :failed_to_render
   end
 
-  qtest d22: %w[full] do
+  qtest a97d22: %w[full] do
     visit('/creator/full?id=chy6BJ')
     assert page.html.include?('<title>cyber-dojo</title>'), :failed_to_render
   end

--- a/test/id58_test_base.rb
+++ b/test/id58_test_base.rb
@@ -21,16 +21,16 @@ class Id58TestBase < Minitest::Test
   # - - - - - - - - - - - - - - - - - - - - - -
 
   def self.qtest(hash, &test_block)
-    id58_suffix = hash.keys[0]
-    lines = hash[id58_suffix].join(' ').split('|').join("\n|")
-    test(id58_suffix, "#{lines}\n\n", &test_block)
+    id58 = hash.keys[0]
+    lines = hash[id58].join(' ').split('|').join("\n|")
+    test(id58, "#{lines}\n\n", &test_block)
   end
 
-  def self.test(id58_suffix, *lines, &test_block)
+  def self.test(id58, *lines, &test_block)
     source = test_block.source_location
     source_file = File.basename(source[0])
     source_line = source[1].to_s
-    id58 = checked_id58(id58_suffix.to_s, lines)
+    id58 = checked_id58(id58.to_s, lines)
     return unless @@args === [] || @@args.any? { |arg| id58.include?(arg) }
 
     space = ' '
@@ -51,7 +51,7 @@ class Id58TestBase < Minitest::Test
         id58_teardown
       end
     }
-    name = "#{id58_suffix}:#{name58}"
+    name = "#{id58}:#{name58}"
     define_method("test_\n\n#{name}".to_sym, &execute_around)
   end
 
@@ -92,28 +92,16 @@ class Id58TestBase < Minitest::Test
       obj.chars.all? { |ch| ID58_ALPHABET.include?(ch) }
   end
 
-  def self.checked_id58(id58_suffix, lines)
-    method = 'def self.id58_prefix'
-    pointer = "#{' ' * method.index('.')}!"
-    pointee = ['', pointer, method, '', ''].join("\n")
-    pointer.prepend("\n\n")
-    raise "#{pointer}missing#{pointee}" unless respond_to?(:id58_prefix)
-
-    prefix = id58_prefix.to_s
-    raise "#{pointer}empty#{pointee}" if prefix === ''
-    raise "#{pointer}not id58#{pointee}" unless id58?(prefix)
-
-    method = "test '#{id58_suffix}',"
+  def self.checked_id58(id58, lines)
+    method = "test '#{id58}',"
     pointer = "#{' ' * method.index("'")}!"
     space = ' '
     proposition = lines.join(space)
     pointee = ['', pointer, method, "'#{proposition}'", '', ''].join("\n")
-    id58 = prefix + id58_suffix
     pointer.prepend("\n\n")
-    raise "#{pointer}empty#{pointee}" if id58_suffix === ''
-    raise "#{pointer}not id58#{pointee}" unless id58?(id58_suffix)
+    raise "#{pointer}empty#{pointee}" if id58 === ''
+    raise "#{pointer}not id58#{pointee}" unless id58?(id58)
     raise "#{pointer}duplicate#{pointee}" if @@seen_ids.include?(id58)
-    raise "#{pointer}overlap#{pointee}" if prefix[-2..] === id58_suffix[0..1]
 
     @@seen_ids << id58
     id58

--- a/test/server/assets_test.rb
+++ b/test/server/assets_test.rb
@@ -2,13 +2,10 @@ require_relative 'creator_test_base'
 require 'digest'
 
 class AssetsTest < CreatorTestBase
-  def self.id58_prefix
-    'Q3p'
-  end
 
   # - - - - - - - - - - - - - - - - -
 
-  test '2Je', %w[
+  test 'Q3p2Je', %w[
     |GET /assets/app.css is served
   ] do
     get '/assets/app.css'
@@ -18,7 +15,7 @@ class AssetsTest < CreatorTestBase
 
   # - - - - - - - - - - - - - - - - -
 
-  test '3Je', %w[
+  test 'Q3p3Je', %w[
     |GET /assets/app.js is served
   ] do
     get '/assets/app.js'
@@ -28,7 +25,7 @@ class AssetsTest < CreatorTestBase
 
   # - - - - - - - - - - - - - - - - -
 
-  test '4Je', %w[
+  test 'Q3p4Je', %w[
     |GET /assets/app.css is served with a long-lived immutable
     |Cache-Control header, so browsers do not re-pull it through
     |nginx's rate-limited /creator/ zone on every page navigation
@@ -41,7 +38,7 @@ class AssetsTest < CreatorTestBase
 
   # - - - - - - - - - - - - - - - - -
 
-  test '5Je', %w[
+  test 'Q3p5Je', %w[
     |GET /assets/app.js is served with a long-lived immutable
     |Cache-Control header, for the same reason as 4Je
   ] do
@@ -53,7 +50,7 @@ class AssetsTest < CreatorTestBase
 
   # - - - - - - - - - - - - - - - - -
 
-  test '6Je', %w[
+  test 'Q3p6Je', %w[
     |the layout references each asset with a ?v=<content-hash>
     |token, so any change to an asset's content yields a new URL
     |that safely busts the immutable browser cache on the next deploy

--- a/test/server/choose_custom_problem_test.rb
+++ b/test/server/choose_custom_problem_test.rb
@@ -1,13 +1,10 @@
 require_relative 'creator_test_base'
 
 class ChooseCustomProblemTest < CreatorTestBase
-  def self.id58_prefix
-    :A73
-  end
 
   # - - - - - - - - - - - - - - - - -
 
-  qtest w18: %w[
+  qtest A73w18: %w[
     |GET/choose_custom_problem
     |offers all custom_start_points names
   ] do

--- a/test/server/choose_language_test.rb
+++ b/test/server/choose_language_test.rb
@@ -1,13 +1,10 @@
 require_relative 'creator_test_base'
 
 class ChooseLanguageTest < CreatorTestBase
-  def self.id58_prefix
-    :D73
-  end
 
   # - - - - - - - - - - - - - - - - -
 
-  qtest w18: %w[
+  qtest D73w18: %w[
     |GET/choose_ltf
     |offers all languages-start-points names
   ] do

--- a/test/server/choose_problem_test.rb
+++ b/test/server/choose_problem_test.rb
@@ -1,13 +1,10 @@
 require_relative 'creator_test_base'
 
 class ChooseProblemTest < CreatorTestBase
-  def self.id58_prefix
-    :B73
-  end
 
   # - - - - - - - - - - - - - - - - -
 
-  qtest w18w: %w[
+  qtest B73w18: %w[
     |GET/choose_problem
     |offers all exercise_start_point names
   ] do

--- a/test/server/create_group_test.rb
+++ b/test/server/create_group_test.rb
@@ -2,9 +2,6 @@ require_relative 'creator_test_base'
 require 'json'
 
 class CreateGroupTest < CreatorTestBase
-  def self.id58_prefix
-    :p42
-  end
 
   def id58_setup
     @display_name = custom_start_points.names.sample
@@ -16,7 +13,7 @@ class CreateGroupTest < CreatorTestBase
 
   # - - - - - - - - - - - - - - - - -
 
-  qtest w9A: %w(
+  qtest p42w9A: %w(
     |POST /create.json
     |with [type=group,exercise_name,language_name] URL params
     |generates json route /creator/enter?id=ID
@@ -33,7 +30,7 @@ class CreateGroupTest < CreatorTestBase
 
   # - - - - - - - - - - - - - - - - -
 
-  qtest w9B: %w(
+  qtest p42w9B: %w(
     |POST /create.json
     |with [type=group,language_name] URL params
     |and empty exercise_name (skipped)
@@ -52,7 +49,7 @@ class CreateGroupTest < CreatorTestBase
 
   # - - - - - - - - - - - - - - - - -
 
-  qtest w9C: %w(
+  qtest p42w9C: %w(
     |POST /create.json
     |with [type=group,display_name] URL params
     |generates json route /creator/enter?id=ID

--- a/test/server/create_kata_test.rb
+++ b/test/server/create_kata_test.rb
@@ -2,9 +2,6 @@ require_relative 'creator_test_base'
 require 'json'
 
 class CreateKataTest < CreatorTestBase
-  def self.id58_prefix
-    :p43
-  end
 
   def id58_setup
     @display_name = custom_start_points.names.sample
@@ -16,7 +13,7 @@ class CreateKataTest < CreatorTestBase
 
   # - - - - - - - - - - - - - - - - -
 
-  qtest w9A: %w(
+  qtest p43w9A: %w(
     |POST /create.json
     |with [type=single,language_name,exercise_name] URL params
     |generates json route /creator/enter?id=ID
@@ -33,7 +30,7 @@ class CreateKataTest < CreatorTestBase
 
   # - - - - - - - - - - - - - - - - -
 
-  qtest w9B: %w(
+  qtest p43w9B: %w(
     |POST /create.json
     |with [type=single,language_name] URL params
     |and empty exercise_name (skipped)
@@ -52,7 +49,7 @@ class CreateKataTest < CreatorTestBase
 
   # - - - - - - - - - - - - - - - - -
 
-  qtest w9C: %w(
+  qtest p43w9C: %w(
     |POST /create.json
     |with [type=single,display_name] URL params
     |generates json route /creator/enter?id=ID

--- a/test/server/external_hostname_test.rb
+++ b/test/server/external_hostname_test.rb
@@ -7,15 +7,12 @@ require_source 'external_runner'
 require_source 'external_saver'
 
 class ExternalHostnameTest < CreatorTestBase
-  def self.id58_prefix
-    :Qs8
-  end
 
   include ScopedEnvVarHelper
 
   # - - - - - - - - - - - - - - - - -
 
-  qtest w10: %w[
+  qtest Qs8w10: %w[
     |ExternalCustomStartPoints
     |has hostname set from env-var
     |CYBER_DOJO_CUSTOM_START_POINTS_HOSTNAME
@@ -31,7 +28,7 @@ class ExternalHostnameTest < CreatorTestBase
 
   # - - - - - - - - - - - - - - - - -
 
-  qtest w11: %w[
+  qtest Qs8w11: %w[
     |ExternalExercisesStartPoints
     |has hostname set from env-var
     |CYBER_DOJO_EXERCISES_START_POINTS_HOSTNAME
@@ -47,7 +44,7 @@ class ExternalHostnameTest < CreatorTestBase
 
   # - - - - - - - - - - - - - - - - -
 
-  qtest w12: %w[
+  qtest Qs8w12: %w[
     |ExternalLanguagesStartPoints
     |has hostname set from env-var
     |CYBER_DOJO_LANGUAGES_START_POINTS_HOSTNAME
@@ -63,7 +60,7 @@ class ExternalHostnameTest < CreatorTestBase
 
   # - - - - - - - - - - - - - - - - -
 
-  qtest w13: %w[
+  qtest Qs8w13: %w[
     |ExternalRunner
     |has hostname set from env-var
     |CYBER_DOJO_RUNNER_HOSTNAME
@@ -79,7 +76,7 @@ class ExternalHostnameTest < CreatorTestBase
 
   # - - - - - - - - - - - - - - - - -
 
-  qtest w14: %w[
+  qtest Qs8w14: %w[
     |ExternalSaver
     |has hostname set from env-var
     |CYBER_DOJO_SAVER_HOSTNAME

--- a/test/server/home_test.rb
+++ b/test/server/home_test.rb
@@ -1,13 +1,10 @@
 require_relative 'creator_test_base'
 
 class HomeTest < CreatorTestBase
-  def self.id58_prefix
-    :Ws9
-  end
 
   # - - - - - - - - - - - - - - - - -
 
-  qtest w18: %w[
+  qtest Ws9w18: %w[
     |GET/home is 200
   ] do
     get '/home'

--- a/test/server/id58_test_test.rb
+++ b/test/server/id58_test_test.rb
@@ -1,35 +1,31 @@
 require_relative 'creator_test_base'
 
 class Id58TestTest < CreatorTestBase
-  def self.id58_prefix
-    :c89
-  end
 
   # - - - - - - - - - - - - - - - - - - - - -
 
-  test 'C80',
+  test 'c89C80',
        'test-id is available via environment variable' do
     assert_equal 'c89C80', ENV['ID58']
   end
 
   # - - - - - - - - - - - - - - - - - - - - -
 
-  test '57B',
-       'test-id is also available via a method',
-       'and is the id58_prefix concatenated with the test-id' do
+  test 'c8957B',
+       'test-id is also available via a method' do
     assert_equal 'c8957B', id58
   end
 
   # - - - - - - - - - - - - - - - - - - - - -
 
-  test '18F',
+  test 'c8918F',
        'test-name is available via a method' do
     assert_equal 'test-name is available via a method', name58
   end
 
   # - - - - - - - - - - - - - - - - - - - - -
 
-  test 'D30',
+  test 'c89D30',
        'test-name can be long',
        'and split over many',
        'comma separated lines',
@@ -47,7 +43,7 @@ class Id58TestTest < CreatorTestBase
 
   # - - - - - - - - - - - - - - - - - - - - -
 
-  test 'D31', %w[
+  test 'c89D31', %w[
     test-name can be long,
     and split over many lines with %w syntax,
     and will automatically be joined with spaces
@@ -62,12 +58,12 @@ class Id58TestTest < CreatorTestBase
 
   # - - - - - - - - - - - - - - - - - - - - -
 
-  test 'E3A', %w[id digits can be hex uppercase] do
+  test 'c89E3A', %w[id digits can be hex uppercase] do
     assert_equal 'c89E3A', ENV['ID58']
     assert_equal 'c89E3A', id58
   end
 
-  test 'e3a', %w[id digits can be hex lowercase] do
+  test 'c89e3a', %w[id digits can be hex lowercase] do
     assert_equal 'c89e3a', ENV['ID58']
     assert_equal 'c89e3a', id58
   end

--- a/test/server/json_hash_parse_helper_test.rb
+++ b/test/server/json_hash_parse_helper_test.rb
@@ -2,15 +2,12 @@ require_relative 'creator_test_base'
 require_source 'json_hash_parse_helper'
 
 class JsonHashParseTest < CreatorTestBase
-  def self.id58_prefix
-    :k3S
-  end
 
   include JsonHashParseHelper
 
   # - - - - - - - - - - - - - - - - -
 
-  qtest u70: %w[
+  qtest k3Su70: %w[
     |json_hash_parse
     |returns {}
     |when body is ''
@@ -22,7 +19,7 @@ class JsonHashParseTest < CreatorTestBase
 
   # - - - - - - - - - - - - - - - - -
 
-  qtest u71: %w[
+  qtest k3Su71: %w[
     |json_hash_parse
     |returns hash
     |when body is a hash
@@ -34,7 +31,7 @@ class JsonHashParseTest < CreatorTestBase
 
   # - - - - - - - - - - - - - - - - -
 
-  qtest u72: %w[
+  qtest k3Su72: %w[
     |json_hash_parse
     |raises RuntimeError
     |when body is not a hash
@@ -47,7 +44,7 @@ class JsonHashParseTest < CreatorTestBase
 
   # - - - - - - - - - - - - - - - - -
 
-  qtest u73: %w[
+  qtest k3Su73: %w[
     |json_hash_parse
     |raises RuntimeError
     |when body is not JSON

--- a/test/server/route_bad_response_test.rb
+++ b/test/server/route_bad_response_test.rb
@@ -2,13 +2,10 @@ require_relative 'creator_test_base'
 require 'ostruct'
 
 class RouteBadResponseTest < CreatorTestBase
-  def self.id58_prefix
-    :f28
-  end
 
   # - - - - - - - - - - - - - - - - -
 
-  qtest QN4: %w[
+  qtest f28QN4: %w[
     |when an http-proxy
     |returns non-JSON in its response.body
     |it logs the exeption to stdout
@@ -19,7 +16,7 @@ class RouteBadResponseTest < CreatorTestBase
 
   # - - - - - - - - - - - - - - - - -
 
-  qtest QN6: %w[
+  qtest f28QN6: %w[
     |when an http-proxy
     |returns JSON-Hash in its response.body
     |which contains the key "exception"
@@ -32,7 +29,7 @@ class RouteBadResponseTest < CreatorTestBase
 
   # - - - - - - - - - - - - - - - - -
 
-  qtest QN7: %w[
+  qtest f28QN7: %w[
     |when an http-proxy
     |returns JSON-Hash in its response.body
     |which does not contain the requested method's key
@@ -49,7 +46,7 @@ class RouteBadResponseTest < CreatorTestBase
 
   # - - - - - - - - - - - - - - - - -
 
-  qtest QN8: %w[
+  qtest f28QN8: %w[
     |when an http-proxy
     |has a 500 error
     |you get the error.erb page
@@ -75,7 +72,7 @@ class RouteBadResponseTest < CreatorTestBase
 
   # - - - - - - - - - - - - - - - - -
 
-  qtest QN9: %w[
+  qtest f28QN9: %w[
     |when an http-proxy
     |has a 500 error
     |and the original exception is not ::HttpJsonHash::ServiceError

--- a/test/server/route_enter_test.rb
+++ b/test/server/route_enter_test.rb
@@ -1,13 +1,10 @@
 require_relative 'creator_test_base'
 
 class RouteEnterTest < CreatorTestBase
-  def self.id58_prefix
-    :d4P
-  end
 
   # - - - - - - - - - - - - - - - - -
 
-  qtest j3K: %w[
+  qtest d4Pj3K: %w[
     |POST /enter.json
     |for a version=2 group
     |has status 200
@@ -34,7 +31,7 @@ class RouteEnterTest < CreatorTestBase
 
   # - - - - - - - - - - - - - - - - -
 
-  qtest x24: %w[
+  qtest d4Px24: %w[
     |POST /enter.json
     |for a version=2 group
     |has status 200

--- a/test/server/route_id_type_test.rb
+++ b/test/server/route_id_type_test.rb
@@ -1,13 +1,10 @@
 require_relative 'creator_test_base'
 
 class RouteIdTypeTest < CreatorTestBase
-  def self.id58_prefix
-    :qed
-  end
 
   # - - - - - - - - - - - - - - - - -
 
-  qtest x23: %w[
+  qtest qedx23: %w[
     |GET /id_type
     |has status 200
     |returns 'group'
@@ -23,7 +20,7 @@ class RouteIdTypeTest < CreatorTestBase
 
   # - - - - - - - - - - - - - - - - -
 
-  qtest x24: %w[
+  qtest qedx24: %w[
     |GET /id_type
     |has status 200
     |returns 'single'
@@ -39,7 +36,7 @@ class RouteIdTypeTest < CreatorTestBase
 
   # - - - - - - - - - - - - - - - - -
 
-  qtest x25: %w[
+  qtest qedx25: %w[
     |GET /id_type
     |has status 200
     |returns nil

--- a/test/server/route_probes_test.rb
+++ b/test/server/route_probes_test.rb
@@ -2,15 +2,12 @@ require_relative 'creator_test_base'
 require 'ostruct'
 
 class RouteProbesTest < CreatorTestBase
-  def self.id58_prefix
-    :a86
-  end
 
   # - - - - - - - - - - - - - - - - -
   # 200
   # - - - - - - - - - - - - - - - - -
 
-  qtest C15: %w[
+  qtest a86C15: %w[
     |GET/alive?
     |has status 200
     |returns true
@@ -24,7 +21,7 @@ class RouteProbesTest < CreatorTestBase
 
   # - - - - - - - - - - - - - - - - -
 
-  qtest D15: %w[
+  qtest a86D15: %w[
     |when all http-proxy are ready
     |GET/ready?
     |has status 200
@@ -39,7 +36,7 @@ class RouteProbesTest < CreatorTestBase
 
   # - - - - - - - - - - - - - - - - -
 
-  qtest E15: %w[
+  qtest a86E15: %w[
     |when custom_start_points http-proxy is not ready
     |GET/ready?
     |has status 200
@@ -53,7 +50,7 @@ class RouteProbesTest < CreatorTestBase
     end
   end
 
-  qtest E16: %w[
+  qtest a86E16: %w[
     |when exercises_start_points http-proxy is not ready
     |GET/ready?
     |has status 200
@@ -67,7 +64,7 @@ class RouteProbesTest < CreatorTestBase
     end
   end
 
-  qtest E17: %w[
+  qtest a86E17: %w[
     |when languages_start_points http-proxy is not ready
     |GET/ready?
     |has status 200
@@ -81,7 +78,7 @@ class RouteProbesTest < CreatorTestBase
     end
   end
 
-  qtest E19: %w[
+  qtest a86E19: %w[
     |when runner http-proxy is not ready
     |GET/ready?
     |has status 200
@@ -97,7 +94,7 @@ class RouteProbesTest < CreatorTestBase
 
   # - - - - - - - - - - - - - - - - -
 
-  qtest F15: %w[
+  qtest a86F15: %w[
     |when saver http-proxy is not ready
     |GET/ready?
     |has status 200
@@ -113,7 +110,7 @@ class RouteProbesTest < CreatorTestBase
 
   # - - - - - - - - - - - - - - - - -
 
-  qtest F16: %w[
+  qtest a86F16: %w[
     |GET/alive?
     |is used by external k8s probes
     |so obeys Postel's Law
@@ -127,7 +124,7 @@ class RouteProbesTest < CreatorTestBase
 
   # - - - - - - - - - - - - - - - - -
 
-  qtest F17: %w[
+  qtest a86F17: %w[
     |GET/ready?
     |is used by external k8s probes
     |so obeys Postel's Law

--- a/test/server/route_sha_test.rb
+++ b/test/server/route_sha_test.rb
@@ -1,13 +1,10 @@
 require_relative 'creator_test_base'
 
 class RouteShaTest < CreatorTestBase
-  def self.id58_prefix
-    :de3
-  end
 
   # - - - - - - - - - - - - - - - - -
 
-  qtest p23: %w[
+  qtest de3p23: %w[
     |GET /sha
     |has status 200
     |returns the 40-char git commit sha used to create the image

--- a/test/server/scoped_env_var_test.rb
+++ b/test/server/scoped_env_var_test.rb
@@ -2,15 +2,12 @@ require_relative 'creator_test_base'
 require_source 'scoped_env_var_helper'
 
 class ScopedEnvVarTest < CreatorTestBase
-  def self.id58_prefix
-    :r7h
-  end
 
   include ScopedEnvVarHelper
 
   # - - - - - - - - - - - - - - - - -
 
-  qtest w9A: %w[
+  qtest r7hw9A: %w[
     |Scoped env-var is present inside the scope only
   ] do
     name = 'BERTY_BASSET'
@@ -24,7 +21,7 @@ class ScopedEnvVarTest < CreatorTestBase
 
   # - - - - - - - - - - - - - - - - -
 
-  qtest w9B: %w[
+  qtest r7hw9B: %w[
     |Scoped env-var resets to previous value at end of scope
   ] do
     name = 'FRED_BASSET'

--- a/test/server/selected_helper_test.rb
+++ b/test/server/selected_helper_test.rb
@@ -2,15 +2,12 @@ require_relative 'creator_test_base'
 require_source 'selected_helper'
 
 class LargestTest < CreatorTestBase
-  def self.id58_prefix
-    '5FF'
-  end
 
   include SelectedHelper
 
   # - - - - - - - - - - - - - - - - - - -
 
-  test '841', %w[
+  test '5FF841', %w[
     select readme.txt content when readme.txt present
     even if not largest content
   ] do
@@ -24,7 +21,7 @@ class LargestTest < CreatorTestBase
 
   # - - - - - - - - - - - - - - - - - - -
 
-  test '842', %w[
+  test '5FF842', %w[
     selected filename when a single visible_file
   ] do
     expected = 'instructions'
@@ -36,7 +33,7 @@ class LargestTest < CreatorTestBase
 
   # - - - - - - - - - - - - - - - - - - -
 
-  test '843', %w[
+  test '5FF843', %w[
     select filename containing the word 'test'
   ] do
     expected = 'hiker.test.js' # javascript-jest
@@ -49,7 +46,7 @@ class LargestTest < CreatorTestBase
 
   # - - - - - - - - - - - - - - - - - - -
 
-  test '844', %w[
+  test '5FF844', %w[
     select filename containing the word 'spec'
   ] do
     expected = 'hiker-spec.js' # javascript-jasmine
@@ -62,7 +59,7 @@ class LargestTest < CreatorTestBase
 
   # - - - - - - - - - - - - - - - - - - -
 
-  test '845', %w[
+  test '5FF845', %w[
     select filename containing the word 'feature'
   ] do
     expected = 'hiker.feature' # javascript-cucumber
@@ -75,7 +72,7 @@ class LargestTest < CreatorTestBase
 
   # - - - - - - - - - - - - - - - - - - -
 
-  test '943', %w[
+  test '5FF943', %w[
     select filename with the largest content
     when more than one file and none are called readme.txt
   ] do

--- a/test/server/views_200_test.rb
+++ b/test/server/views_200_test.rb
@@ -1,30 +1,27 @@
 require_relative 'creator_test_base'
 
 class Views200Test < CreatorTestBase
-  def self.id58_prefix
-    :a49
-  end
 
   # - - - - - - - - - - - - - - - - - - - - - - - - - - -
 
-  qtest AB0: %w[GET /creator/home 200] do
+  qtest a49AB0: %w[GET /creator/home 200] do
     assert_get_200_html('/creator/home')
   end
 
-  qtest AA0: %w[GET /creator/choose_problem 200] do
+  qtest a49AA0: %w[GET /creator/choose_problem 200] do
     assert_get_200_html('/creator/choose_problem')
   end
 
-  qtest AA1: %w[GET /creator/choose_custom_problem 200] do
+  qtest a49AA1: %w[GET /creator/choose_custom_problem 200] do
     assert_get_200_html('/creator/choose_custom_problem')
   end
 
-  qtest AA2: %w[GET /creator/choose_ltf 200] do
+  qtest a49AA2: %w[GET /creator/choose_ltf 200] do
     exercise_name = exercises_start_points.names.sample
     assert_get_200_html('/creator/choose_ltf', exercise_name: exercise_name)
   end
 
-  qtest AA3: %w[GET /creator/choose_type 200] do
+  qtest a49AA3: %w[GET /creator/choose_type 200] do
     exercise_name = exercises_start_points.names.sample
     language_name = languages_start_points.names.sample
     assert_get_200_html('/creator/choose_type', exercise_name: exercise_name, language_name: language_name)
@@ -33,21 +30,21 @@ class Views200Test < CreatorTestBase
 
   # - - - - - - - - - - - - - - - - - - - - - - - - - - -
 
-  qtest AC2: %w[GET /creator/enter 200] do
+  qtest a49AC2: %w[GET /creator/enter 200] do
     assert_get_200_html('/creator/enter', id: group_id)
     assert_get_200_html('/creator/enter', id: kata_id)
     assert_get_200_html('/creator/enter')
   end
 
-  qtest AC3: %w[GET /creator/avatar 200] do
+  qtest a49AC3: %w[GET /creator/avatar 200] do
     assert_get_200_html('/creator/avatar', id: kata_id)
   end
 
-  qtest AC4: %w[GET /creator/reenter 200] do
+  qtest a49AC4: %w[GET /creator/reenter 200] do
     assert_get_200_html('/creator/reenter', id: group_id)
   end
 
-  qtest AC5: %w[GET /creator/full 200] do
+  qtest a49AC5: %w[GET /creator/full 200] do
     assert_get_200_html('/creator/full', id: group_id)
   end
 


### PR DESCRIPTION
  Each test's id was split 3+3: a shared id58_prefix class method per file plus a
  3-char per-test suffix, concatenated at runtime. So the real id (eg Q3p2Je) was
  never written down anywhere -- you couldn't grep for it, and adding a test meant
  reasoning about prefix/suffix overlap rules. Inline the prefix into every test
  id so the id you read is the id that runs, matching ../saver.

  Drop the now-redundant machinery from id58_test_base: test/qtest take the full
  id directly, and checked_id58 validates that id (non-empty, id58-alphabet,
  unique) instead of assembling prefix+suffix, requiring an id58_prefix method,
  and checking prefix/suffix overlap. The lone 4-char outlier (choose_problem's
  w18w) becomes B73w18. Server suite stays green: 68 runs, 399 assertions.

  Also staged (unrelated):
  - Makefile: mark `test` (and `demo`) .PHONY, so `make test` runs the recipe instead of being skipped as "up to date" because the test/ directory exists.
  - build_tagged_images.sh: use the shared on_ci helper rather than an inline CI=true check.
  - bump test/{server,client}/max_metrics.json line counts for the smaller files.

  Co-Authored-By: Claude Opus 4.8 (1M context) <noreply@anthropic.com>