### PR TITLE
Drop dead asset curls from demo smoke-test

### DIFF
--- a/bin/demo.sh
+++ b/bin/demo.sh
@@ -55,9 +55,6 @@ api_demo()
   curl_json_body_200 GET ready
   curl_json_body_200 GET sha
   echo
-  curl_200 assets/app.css 'Content-Type: text/css'
-  curl_200 assets/app.js  'Content-Type: application/javascript'
-  echo
   curl_200 home   'Content-Type: text/html'
   curl_200 choose_problem 'Content-Type: text/html'
   curl_200 choose_custom_problem 'Content-Type: text/html'


### PR DESCRIPTION
  The api_demo smoke-test curled assets/app.css and assets/app.js, but
  these un-fingerprinted routes no longer exist. Since b787e34 asset URLs
  are fingerprinted by content hash (/assets/app-<hash>.css|js), computed
  at runtime, so the old paths now 404. The hash cannot be hardcoded here,
  so rather than scrape it from a page's HTML, drop the two asset curls.

  Co-Authored-By: Claude Opus 4.8 (1M context) <noreply@anthropic.com>