### PR TITLE
Stop publishing test-stack host ports so concurrent runs don't collide

### DIFF
--- a/docker-compose.demo.yml
+++ b/docker-compose.demo.yml
@@ -23,6 +23,13 @@ services:
       - differ
       - dashboard
 
+  # Publish creator on the host for the demo only. bin/demo.sh's api_demo
+  # curls the creator server directly on CYBER_DOJO_CREATOR_PORT (not through
+  # nginx) to bypass nginx's /creator/ rate-limit. The base docker-compose.yml
+  # deliberately publishes no host ports (see its comment).
+  creator:
+    ports: [ "${CYBER_DOJO_CREATOR_PORT}:${CYBER_DOJO_CREATOR_PORT}" ]
+
   web:
     image: ${CYBER_DOJO_WEB_IMAGE}:${CYBER_DOJO_WEB_TAG}
     platform: linux/amd64

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -1,4 +1,12 @@
 
+# No service publishes a host port. The tests reach every service by its
+# compose service name over the project's private network (the browser in the
+# selenium container hits http://nginx_stub:80, the client reaches
+# http://selenium:4444/wd/hub, and so on), so nothing needs a host port. Not
+# publishing means several test runs - in this repo or in sibling repos - can
+# run at once without fighting over the same host ports (eg 80, 4444). The demo
+# overlay (docker-compose.demo.yml) publishes the few ports the demo needs.
+
 services:
 
   # The client/selenium tests run against this cut-down nginx stub, NOT the
@@ -12,7 +20,6 @@ services:
   nginx_stub:
     image: cyberdojo/nginx_creator_stub
     platform: linux/amd64
-    ports: [ "${CYBER_DOJO_NGINX_PORT}:${CYBER_DOJO_NGINX_PORT}" ]
     user: root
     build:
       context: nginx_stub
@@ -28,7 +35,6 @@ services:
     image: ${CYBER_DOJO_CREATOR_CLIENT_IMAGE}:${CYBER_DOJO_CREATOR_TAG}
     platform: linux/amd64
     env_file: [ .env ]
-    ports: [ "${CYBER_DOJO_CREATOR_CLIENT_PORT}:${CYBER_DOJO_CREATOR_CLIENT_PORT}" ]
     user: ${CYBER_DOJO_CREATOR_CLIENT_USER}
     depends_on:
       - custom-start-points    # for test data
@@ -56,7 +62,6 @@ services:
     image: ${CYBER_DOJO_CREATOR_IMAGE}:${CYBER_DOJO_CREATOR_TAG}
     platform: linux/amd64
     env_file: [ .env ]
-    ports: [ "${CYBER_DOJO_CREATOR_PORT}:${CYBER_DOJO_CREATOR_PORT}" ]
     user: ${CYBER_DOJO_CREATOR_SERVER_USER}
     depends_on:
       - custom-start-points
@@ -147,4 +152,3 @@ services:
   selenium:
     image: selenium/standalone-firefox
     platform: linux/amd64
-    ports: [ "4444:4444" ]


### PR DESCRIPTION
  The test compose published fixed host ports (nginx_stub 80, client 9999,
  creator 4523, selenium 4444). Those mappings were dead weight: the tests
  reach every service by its compose service name over the project's private
  network (the selenium browser hits http://nginx_stub:80, the client reaches
  http://selenium:4444/wd/hub, creator by hostname). But by binding the host
  they made a test run fight any sibling repo's test or demo for the same
  ports - port 80 and 4444 especially - so "port is already allocated"
  aborted the run.

  Publish nothing from the test compose; let the private network carry all
  inter-service traffic. The demo still needs two host ports, so the demo
  overlay publishes them itself: nginx (already, via CYBER_DOJO_NGINX_HOST_PORT)
  and creator, whose api_demo curls the server directly to bypass nginx's
  /creator/ rate-limit.

  Co-Authored-By: Claude Opus 4.8 (1M context) <noreply@anthropic.com>