### PR TITLE
Remove dead else branch in display-names chooser setup

### DIFF
--- a/app/assets/javascripts/creator.js
+++ b/app/assets/javascripts/creator.js
@@ -43,18 +43,12 @@ cd.setupDisplayNamesClickHandlers = () => {
 
   const $random = $displayNames.random();
   $random[0].scrollIntoView(); // scrollIntoView is a DOM method, not jQuery
-  if ($next.prop('disabled')) {
-    // The exercise chooser opens with next disabled. Preview a random exercise
-    // (shown as if the mouse were hovering over it) but leave it unselected, so
-    // next stays disabled until the user actually clicks a name.
-    $random.addClass('previewed');
-    $resting = $random;
-    showContent($random);
-  } else {
-    // The other choosers preselect the random name so their next button always
-    // has a valid selection.
-    select($random);
-  }
+  // The choosers open with next disabled. Preview a random exercise (shown as
+  // if the mouse were hovering over it) but leave it unselected, so next stays
+  // disabled until the user actually clicks a name.
+  $random.addClass('previewed');
+  $resting = $random;
+  showContent($random);
 };
 
 cd.urlParams = () => {

--- a/bin/demo.sh
+++ b/bin/demo.sh
@@ -90,9 +90,7 @@ api_demo
 if [ "${1:-}" = '--no-browser' ]; then
   compose down --remove-orphans
 else
-  # Open /creator/home directly rather than the bare '/'. nginx rewrites '/' to
-  # /creator/home with an absolute 301 built from its internal listen port (80),
-  # not the published host port, which would strip the port and send the browser
-  # to :80. Hitting /creator/home skips that rewrite and stays on this port.
-  open "http://localhost:${CYBER_DOJO_NGINX_HOST_PORT}/creator/home"
+  # nginx rewrites '/' to /creator/home with a relative 301 (absolute_redirect
+  # off), so the browser follows it while keeping this host port.
+  open "http://localhost:${CYBER_DOJO_NGINX_HOST_PORT}"
 fi

--- a/docs/demo-nginx-port-redirect-bug.md
+++ b/docs/demo-nginx-port-redirect-bug.md
@@ -2,9 +2,10 @@
 
 ## Status
 
-Worked around, not fixed. `bin/demo.sh` now opens `/creator/home` directly to
-sidestep the redirect. The underlying nginx behaviour is still present and
-worth looking into.
+Fixed. The cyber-dojo nginx image now sets `absolute_redirect off;`, so the
+`^/$` rewrite emits a relative `Location: /creator/home` and the browser keeps
+whatever port it is on. `bin/demo.sh` opens the bare root URL again; the earlier
+`/creator/home` workaround has been reverted.
 
 ## Symptom
 
@@ -68,21 +69,28 @@ to host port 81 (so the web and creator demos can run side by side without a
 port clash) exposed the mismatch between nginx's internal listen port and the
 published host port.
 
-## Workaround in place
+## The fix
 
-`bin/demo.sh` now opens the final URL directly:
+`absolute_redirect off;` was added to the server block in the cyber-dojo nginx
+image (`nginx.conf.template`). All the `permanent` rewrites in that block are
+same-host redirects, so relative `Location` headers are correct for each: the
+browser keeps whatever scheme, host and port it connected on.
 
 ```
-open "http://localhost:${CYBER_DOJO_NGINX_HOST_PORT}/creator/home"
+absolute_redirect off;
+
+rewrite ^/$              /creator/home permanent;
 ```
 
-## Options for a proper fix (to investigate)
+`bin/demo.sh` opens the bare root URL again:
 
-- Set `absolute_redirect off;` in the nginx config so the `^/$` rewrite emits a
-  relative `Location: /creator/home`; the browser then keeps whatever port it
-  is already on. This lives in the cyber-dojo nginx image, not this repo.
-- Or set `port_in_redirect off;` (weaker: only affects the port, and still
-  depends on the absolute form).
-- Confirm whether any other absolute redirects in the nginx config have the
-  same host-port assumption.
+```
+open "http://localhost:${CYBER_DOJO_NGINX_HOST_PORT}"
+```
+
+### Rejected alternative
+
+`port_in_redirect off;` also fixes this case but is weaker: it drops only the
+port and still depends on nginx constructing an absolute URL. `absolute_redirect
+off` sidesteps the absolute form entirely.
 ```


### PR DESCRIPTION
  All three choosers that render display_names.erb (choose_problem,
  choose_custom_problem, choose_ltf) render the next button as disabled,
  so $next.prop('disabled') is always true on open. The else branch that
  preselected the random name for "other choosers" was unreachable, and
  its comment described choosers that no longer exist.

  Collapse to the single reachable path: preview a random exercise
  unselected, leaving next disabled until the user clicks a name.